### PR TITLE
Prefix post file names with date

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This repository uses git submodules for hugo themes. To clone the repo, you must
 
 ### Write new post
 
-From the repository root, run `hugo new posts/my-title.md`.
+From the repository root, run `./new-post.sh "Some epic title"`.
 
-This will create a new file in `content/posts/my-title.md`, where you can write your content.
+This will create a new file in `content/posts/YYYY-MM-DD_some-epic-title.md`, where you can write your content.
 
 ### Run server locally
 

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,8 @@
+---
+title: "{{ replace (index (split .File.ContentBaseName "_") 1) "-"  " " | title }}"
+date: {{ .Date }}
+tags: []
+featured_image: ""
+description: ""
+slug: "{{ index (split .File.ContentBaseName "_") 1 }}"
+---

--- a/content/posts/2021-12-22_aws-timestream.md
+++ b/content/posts/2021-12-22_aws-timestream.md
@@ -4,6 +4,7 @@ date: 2021-12-22T15:50:15+01:00
 tags: [AWS, Timestream, Python]
 featured_image: ""
 description: "Trying out AWS Timestream in a small side project"
+slug: "aws-timestream"
 ---
 
 AWS recently (last year) released their new server-less database focused purely on time series data, Amazon Timestream. On their product page, AWS describes the database like:

--- a/content/posts/2022-01-26_automated-ec2-setup.md
+++ b/content/posts/2022-01-26_automated-ec2-setup.md
@@ -3,6 +3,7 @@ title: "How I've automated the setup of my virtual server"
 date: 2022-01-21T05:57:22+01:00
 tags: [ Automation, Infrastructure as Code, AWS, Terraform, Ansible, Github Actions]
 description: ""
+slug: "automated-ec2-setup"
 ---
 Lately I've been looking for a good way of hosting some personal projects. I wanted something relatively cheap which I could use to host multiple services. A colleague of mine have for a long time used a single virtual server (more specifically, an EC2 instance in AWS) where he runs multiple services inside docker containers. To enable access to each individual service, there's a nginx reverse proxy that forwards traffic to services. I decided to try the same approach.
 

--- a/new-post.sh
+++ b/new-post.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$1" ];
+then
+  echo "Missing title"
+  exit 1
+fi
+
+DATE=$(date +%Y-%m-%d)
+TITLE=$(echo "$1" | tr ' ' '-' | awk '{print tolower($0)}')
+hugo new "posts/${DATE}_${TITLE}.md"

--- a/quickstart/archetypes/default.md
+++ b/quickstart/archetypes/default.md
@@ -1,6 +1,0 @@
----
-title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
-draft: true
----
-


### PR DESCRIPTION
In this pull request I've introduced a shell script for creating new posts. The reason for using a shell script is to automatically include a date prefix in the file name.
In order to maintain pretty urls to our posts I've overridden `default.md` from our theme in order to automatically include a `slug` property to the new post.

By running `./new-post.sh "Some epic title"` you will get a new file named `YYYY-MM-DD_some-epic-title` with a slug property of `some-epic-title`.