### PR TITLE
Show date of posts in list views

### DIFF
--- a/layouts/partials/custom-date.html
+++ b/layouts/partials/custom-date.html
@@ -1,0 +1,3 @@
+<time class="f6 mv2 dib tracked" {{ printf `datetime="%s" ` (.Date.Format "2006-01-02T15:04:05Z07:00" ) | safeHTMLAttr }}>
+    {{- .Date.Format (default "January 2, 2006" .Site.Params.date_format) -}}
+</time>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -1,0 +1,29 @@
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+<article class="bb b--black-10">
+  <div class="db pv4 ph3 ph0-l no-underline dark-gray">
+    <div class="flex flex-column flex-row-ns">
+      {{ if $featured_image }}
+          {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+        {{ $featured_image := (trim $featured_image "/") | absURL }}
+        <div class="pr3-ns mb4 mb0-ns w-100 w-40-ns">
+          <a href="{{.RelPermalink}}" class="db grow">
+            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
+          </a>
+        </div>
+      {{ end }}
+      <div class="blah w-100{{ if $featured_image }} w-60-ns pl3-ns{{ end }}">
+        <h1 class="f3 fw1 athelas mt0 lh-title">
+          <a href="{{.RelPermalink}}" class="color-inherit dim link">
+            {{ .Title }}
+            </a>
+        </h1>
+        <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
+          {{ .Summary }}
+        </div>
+          <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+        {{/* TODO: add author
+        <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
+      </div>
+    </div>
+  </div>
+</article>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -17,6 +17,7 @@
             {{ .Title }}
             </a>
         </h1>
+        {{ partial "custom-date.html" . }}
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -1,0 +1,13 @@
+<div class="relative w-100 mb4 bg-white nested-copy-line-height">
+  <div class="bg-white mb3 pa4 gray overflow-hidden">
+    <span class="f6 db">{{ humanize .Section }}</span>
+    <h1 class="f3 near-black">
+      <a href="{{ .RelPermalink }}" class="link black dim">
+        {{ .Title }}
+      </a>
+    </h1>
+    <div class="nested-links f5 lh-copy nested-copy-line-height">
+      {{ .Summary  }}
+    </div>
+  </div>
+</div>

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -6,6 +6,7 @@
         {{ .Title }}
       </a>
     </h1>
+    {{ partial "custom-date.html" . }}
     <div class="nested-links f5 lh-copy nested-copy-line-height">
       {{ .Summary  }}
     </div>


### PR DESCRIPTION
To show dates in list views it seems like we need to customize our theme. In order to do this I've copied `summary-with-image.html` and `summary.html` (the two templates responsible for rendering posts in list views) from our themes folder to `layouts/partials/*`.

I've then modified both these templates to include another partial, `custom-date.html` in order to show dates in both list views.

More on theme customization: https://gohugobrasil.netlify.app/themes/customizing/

Resolves #23 