### PR TITLE
Add a title to the blog

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 theme = "ananke"
 baseURL = "https://deviesdevelopment.github.io/blog"
+title = "Devies blog"
 
 [params]
   site_logo = "/blog/logo.png"


### PR DESCRIPTION
The title is added to the `<title>`-element on the main page (which is empty right now). Apart from that it's added on top of the featured image (see below).

![2022-05-17-082206_2317x969_scrot](https://user-images.githubusercontent.com/9256450/168743704-51cfb614-91ec-4434-a31b-96895f52d40c.png)
