### PR TITLE
enable unsafe to see custom HTML in markdown?

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,3 +6,5 @@ title = "Devies blog"
   site_logo = "/blog/logo.png"
   favicon = "favicon.ico"
   featured_image = "sparvagn.jpg"
+[markup.goldmark.renderer] 
+  unsafe = true


### PR DESCRIPTION
The "We Got Cached 😱" post from May 13, 2022 was meant to have some colored texts that came from custom html tags in the markdown. Specifically it was a couple of spans, `<span style="font-family:Arial;color:#00c0ff;">...</span>`, that didn't get reflected in the post. 

From [this guide](https://www.markdownguide.org/tools/hugo/), I found that Hugo does support HTML in this way, but it is set disabled as default. The page links to [this configuration guide page](https://www.markdownguide.org/tools/hugo/) which shows the following _default_ configuration (among many others):
```toml
[mark]
  [markup.goldmark]
    [markup.goldmark.renderer]
      unsafe = false
```

It seemed enough for me to add the following the already existing `config.toml` for the expected behavior to occur:
```toml
[markup.goldmark.renderer]
  unsafe = true
```

The question is what unwanted behavior will come from this, if we choose to enable it. 