### PR TITLE
Trick a local web server using Host header

### DIFF
--- a/content/posts/2022-05-20_host-header.md
+++ b/content/posts/2022-05-20_host-header.md
@@ -1,0 +1,24 @@
+---
+title: "Some title"
+date: 2022-05-20T14:56:30+02:00
+tags: [ nginx, DNS ]
+featured_image: ""
+description: ""
+slug: "some-title"
+author:
+ - Rickard Andersson
+---
+
+**TLDR**: If you need to "trick" a local web server that you're making requests to a certain domain, but do not want (or have permissions) to modify `/etc/hosts` - Set the intended domain in the `Host` request header instead.
+
+---
+
+We are currently working on a project where we have an nginx instance that is redirecting traffic for many different domains. In our case, the nginx is an ingress controller in a kubernetes cluster, but you might use a similar approach if you're hosting multiple websites on the same webserver.
+
+During development we often need to make requests to an nginx that runs locally, but have it behave as if a request was made to e.g. *my-domain.com*. A common approach to accomplish this is to modify the [`/etc/hosts`](https://en.wikipedia.org/wiki/Hosts_(file)) file so that *my-domain.com* resolves to *localhost*. However, this might not always be feasible or possible. If you need to change the domain often, it can be cumbersome to make file changes in between, or perhaps you need to do this on a build agent where you don't have permissions to modify the file.
+
+In cases like this, you can instead set the `Host` request header to the intended domain. For example, to make a request to *localhost* but have the web server behave as if the request was made to *my-domain.com*:
+
+```bash
+curl localhost -H Host:mydomain.com
+```

--- a/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
+++ b/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
@@ -1,10 +1,10 @@
 ---
-title: "Some title"
+title: "Trick your local web server using the Host header"
 date: 2022-05-20T14:56:30+02:00
 tags: [ nginx, DNS ]
 featured_image: ""
 description: ""
-slug: "some-title"
+slug: "trick-local-web-server-using-host-header"
 author:
  - Rickard Andersson
 ---

--- a/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
+++ b/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
@@ -22,3 +22,5 @@ In cases like this, you can instead set the `Host` request header to the intende
 ```bash
 curl localhost -H Host:my-domain.com
 ```
+
+For the project I mentioned above we use this approach when running end-to-end tests in our CI pipeline.

--- a/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
+++ b/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
@@ -15,7 +15,7 @@ author:
 
 We are currently working on a project where we have an nginx instance that is redirecting traffic for many different domains. In our case, the nginx is an ingress controller in a kubernetes cluster, but you might use a similar approach if you're hosting multiple websites on the same webserver.
 
-During development we often need to make requests to an nginx that runs locally, but have it behave as if a request was made to e.g. *my-domain.com*. A common approach to accomplish this is to modify the [`/etc/hosts`](https://en.wikipedia.org/wiki/Hosts_(file)) file so that *my-domain.com* resolves to *localhost*. However, this might not always be feasible or possible. If you need to change the domain often, it can be cumbersome to make file changes in between, or perhaps you need to do this on a build agent where you don't have permissions to modify the file.
+During development we often need to make requests to an nginx that runs locally, but have it behave as if a request was made to e.g. *my-domain.com*. A common approach to accomplish this is to modify the [`/etc/hosts`](https://en.wikipedia.org/wiki/Hosts_(file)) file so that *my-domain.com* resolves to *localhost*. However, this might not always be feasible or possible. If you need to change the domain often, it can be cumbersome to make file changes in between, or perhaps you need to do this on a machine where you don't have permissions to modify the file (e.g. a build agent).
 
 In cases like this, you can instead set the `Host` request header to the intended domain. For example, to make a request to *localhost* but have the web server behave as if the request was made to *my-domain.com*:
 

--- a/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
+++ b/content/posts/2022-05-20_trick-local-web-server-using-host-header.md
@@ -20,5 +20,5 @@ During development we often need to make requests to an nginx that runs locally,
 In cases like this, you can instead set the `Host` request header to the intended domain. For example, to make a request to *localhost* but have the web server behave as if the request was made to *my-domain.com*:
 
 ```bash
-curl localhost -H Host:mydomain.com
+curl localhost -H Host:my-domain.com
 ```


### PR DESCRIPTION
Add post on using the Host request header instead of `/etc/hosts` to trick local web server! We recently used this approach in [kubesquid](https://github.com/DeviesDevelopment/kubesquid) for e2e testing.