### PR TITLE
Add custom style for inline code blocks

### DIFF
--- a/assets/ananke/css/custom.css
+++ b/assets/ananke/css/custom.css
@@ -1,0 +1,5 @@
+:not(pre) > code {
+  font-size: 0.8em;
+  background-color: #dcdcdc;
+  padding: 2px;
+}

--- a/config.toml
+++ b/config.toml
@@ -6,5 +6,6 @@ title = "Devies blog"
   site_logo = "/blog/logo.png"
   favicon = "favicon.ico"
   featured_image = "sparvagn.jpg"
+  custom_css = ["custom.css"]
 [markup.goldmark.renderer] 
   unsafe = true


### PR DESCRIPTION
The font size for inline code blocks is currently way to large. What do you think about this?

Before:
![2022-05-20-162444_619x184_scrot](https://user-images.githubusercontent.com/9256450/169549175-036d034a-06ac-4970-af64-1ef926f79216.png)

After:
![2022-05-20-162432_581x107_scrot](https://user-images.githubusercontent.com/9256450/169549173-9841a20d-d24f-4d78-a148-e7c46ac5af89.png)

Resolves https://github.com/DeviesDevelopment/blog/issues/22.