### PR TITLE
Update timestamp on primitive obsession post

### DIFF
--- a/content/posts/2022-07-29_mitigating-primitive-obsession-in-asp.net-web-api.md
+++ b/content/posts/2022-07-29_mitigating-primitive-obsession-in-asp.net-web-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Mitigating Primitive Obsession in ASP.NET Web Api"
-date: 2022-07-27T15:20:58+02:00
+date: 2022-07-29T15:43:58+02:00
 tags: [ "ASP.NET", ".NET", "code smells" ]
 featured_image: ""
 description: ""


### PR DESCRIPTION
No slack notification was posted to #general when this post was published.
I think that it may be because a post with a later publication date has already been posted.

Let's update the timestamp and see if that triggers a notification.