### PR TITLE
Rename deploy job to build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This change will remove the confusion that the PR gets deployed before it is merged. 

We only deploy when we merge to master, and before that, we only check that the blog builds.

This change will make @BunnyFiscuit 's life a bit longer! 