### PR TITLE
Prevent new containers when running hugo script

### DIFF
--- a/hugo.sh
+++ b/hugo.sh
@@ -3,6 +3,8 @@
 HUGO_VERSION="0.145.0"
 
 docker run \
+        --name devies-blog \
+        --rm \
         -p 1313:1313 \
         -v ${PWD}:/src \
         hugomods/hugo:exts-"$HUGO_VERSION" "$@"


### PR DESCRIPTION
By using the --rm flag.

In addition I've set a name for the container